### PR TITLE
EDG-32: add static linux sdk and build aarch64

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
   build-linux:
     name: Build and Test on Linux
     
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     container:
       image: swift:6.1.0
     

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Find binary path
       id: get-binary
       run: |
-        BIN_PATH=$(swift build --configuration release --show-bin-path)
+        BIN_PATH=$(swift build --configuration release --show-bin-path --swift-sdk aarch64-swift-linux-musl)
         echo "Build directory contents:"
         
         if [ -f "$BIN_PATH/edge-agent" ]; then

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,8 +20,11 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+    - name: Install Static Linux SDK
+      run: |
+        swift sdk install https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
     - name: Build
-      run: swift build --configuration release --product edge-agent
+      run: swift build --configuration release --product edge-agent --swift-sdk aarch64-swift-linux-musl
     - name: Find binary path
       id: get-binary
       run: |
@@ -46,7 +49,7 @@ jobs:
       id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
-        name: edge-agent-linux
+        name: edge-agent-linux-aarch64
         path: ${{ env.BINARY_PATH }}
         retention-days: 14
         if-no-files-found: error
@@ -65,7 +68,7 @@ jobs:
       id: create_release
       uses: softprops/action-gh-release@v2
       with:
-        name: Release ${{ env.VERSION }}
+        name: Release ${{ env.VERSION }} (aarch64)
         tag_name: ${{ env.VERSION }}
         draft: false
         prerelease: false


### PR DESCRIPTION
The current builds don't run on a Raspberry PI because they are not explicitly built for aarch64. Also, the swift SDK is not present on the device, so we need to statically link.