### PR TITLE
Fix needing to press "Debug anyway"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .build
+.edge-build
 /Packages
 xcuserdata/
 DerivedData/

--- a/Sources/EdgeCLI/SwiftPM.swift
+++ b/Sources/EdgeCLI/SwiftPM.swift
@@ -22,7 +22,11 @@ public struct SwiftPM: Sendable {
         /// Build the specified product.
         case product(String)
 
+        /// Decrease verbosity to only include error output.
         case quiet
+
+        /// Specify a custom scratch directory path (default .build)
+        case scratchPath(String)
 
         /// The arguments to pass to the Swift build command.
         var arguments: [String] {
@@ -37,6 +41,8 @@ public struct SwiftPM: Sendable {
                 return ["--product", product]
             case .quiet:
                 return ["--quiet"]
+            case .scratchPath(let path):
+                return ["--scratch-path", path]
             }
         }
     }

--- a/Sources/edge-agent/DockerCLI.swift
+++ b/Sources/edge-agent/DockerCLI.swift
@@ -34,6 +34,9 @@ public struct DockerCLI: Sendable {
         /// Assign a name to the container
         case name(String)
 
+        /// Run container in background and print container ID
+        case detach
+
         /// The arguments to pass to the Docker run command.
         var arguments: [String] {
             switch self {
@@ -53,6 +56,8 @@ public struct DockerCLI: Sendable {
                 return ["--network", network]
             case .name(let name):
                 return ["--name", name]
+            case .detach:
+                return ["--detach"]
             }
         }
     }

--- a/Sources/edge-agent/Services/EdgeAgentService.swift
+++ b/Sources/edge-agent/Services/EdgeAgentService.swift
@@ -1,6 +1,9 @@
 import EdgeAgentGRPC
+import Logging
 
 struct EdgeAgentService: Edge_Agent_Services_V1_EdgeAgentService.ServiceProtocol {
+    let logger = Logger(label: "EdgeAgentService")
+
     func runContainer(
         request: StreamingServerRequest<Edge_Agent_Services_V1_RunContainerRequest>,
         context: ServerContext
@@ -15,6 +18,7 @@ struct EdgeAgentService: Edge_Agent_Services_V1_EdgeAgentService.ServiceProtocol
                 // Add a task to write outgoing events to the response.
                 group.addTask { [events = handler.events] in
                     for try await event in events {
+                        logger.debug("Sending event: \(event)")
                         try await writer.write(event.proto)
                     }
                 }

--- a/Sources/edge-agent/Services/RunContainerRequestHandler.swift
+++ b/Sources/edge-agent/Services/RunContainerRequestHandler.swift
@@ -160,7 +160,12 @@ struct RunContainerRequestHandler {
             )
             try await dockerCLI.rm(options: [.force], container: containerName)
 
-            var runOptions: [DockerCLI.RunOption] = [.rm, .network("host"), .name(containerName)]
+            var runOptions: [DockerCLI.RunOption] = [
+                .rm,
+                .network("host"),
+                .name(containerName),
+                .detach,
+            ]
             var debugPort: UInt32 = 0
 
             if run.debug {

--- a/Sources/edge/Commands/RunCommand.swift
+++ b/Sources/edge/Commands/RunCommand.swift
@@ -158,14 +158,18 @@ struct RunCommand: AsyncParsableCommand {
                 for try await message in response.messages {
                     switch message.responseType {
                     case .started(let started):
+                        if started.debugPort != 0 {
+                            logger.info(
+                                "Started container with debug port \(started.debugPort)"
+                            )
+                        } else {
+                            logger.info("Started container")
+                        }
                         if detach {
-                            if started.debugPort != 0 {
-                                print("Started container with debug port \(started.debugPort)")
-                            }
                             return
                         }
                     case nil:
-                        ()
+                        logger.warning("Unknown message received from agent")
                     }
                 }
             }

--- a/Sources/edge/Commands/RunCommand.swift
+++ b/Sources/edge/Commands/RunCommand.swift
@@ -52,13 +52,15 @@ struct RunCommand: AsyncParsableCommand {
 
         try await swiftPM.build(
             .product(executableTarget.name),
-            .swiftSDK(swiftSDK)
+            .swiftSDK(swiftSDK),
+            .scratchPath(".edge-build")
         )
 
         let binPath = try await swiftPM.build(
             .showBinPath,
             .swiftSDK(swiftSDK),
-            .quiet
+            .quiet,
+            .scratchPath(".edge-build")
         ).trimmingCharacters(in: .whitespacesAndNewlines)
         let executable = URL(fileURLWithPath: binPath).appendingPathComponent(executableTarget.name)
 


### PR DESCRIPTION
Now runs the container with `--detach` so the agent isn't blocked until after executing the built product.

Also contains a few other fixes that I still had locally.