### PR TITLE
EDG-51 Merge host and port parameters into a single host:port option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Swift Tests
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04-arm
+            container: swift:6.1.0
+          - os: macos-15
+            xcode-select: /Applications/Xcode_16.3.app
+
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: xcode-select
+        if: ${{ matrix.xcode-select != '' }}
+        run: |
+          sudo xcode-select --switch ${{ matrix.xcode-select }}
+
+      - name: Build
+        run: swift build
+
+      - name: Run Tests
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f5c739301125cfe05904d34b63cac2cc463a75f1edc6b81c6185182905bd3759",
+  "originHash" : "c635a5b39edee93bd412bdd3d80b3f36138d77e73b95c8a9b1138558295f2b91",
   "pins" : [
     {
       "identity" : "grpc-swift",

--- a/Package.swift
+++ b/Package.swift
@@ -98,5 +98,13 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log")
             ]
         ),
+
+        /// Tests for EdgeCLI components
+        .testTarget(
+            name: "EdgeCLITests",
+            dependencies: [
+                .target(name: "edge"),
+            ]
+        ),
     ]
 )

--- a/Sources/edge/Commands/RunCommand.swift
+++ b/Sources/edge/Commands/RunCommand.swift
@@ -99,9 +99,10 @@ struct RunCommand: AsyncParsableCommand {
             outputPath: outputPath
         )
 
+        let agentEndpoint = agentConnectionOptions.agent
         let target = ResolvableTargets.DNS(
-            host: agentConnectionOptions.agentHost,
-            port: agentConnectionOptions.agentPort
+            host: agentEndpoint.host,
+            port: agentEndpoint.port
         )
         #if os(macOS)
             let transport = try HTTP2ClientTransport.TransportServices(

--- a/Tests/EdgeCLITests/AgentConnectionOptionsTests.swift
+++ b/Tests/EdgeCLITests/AgentConnectionOptionsTests.swift
@@ -1,0 +1,123 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import edge
+
+@Suite("AgentConnectionOptions")
+struct AgentConnectionOptionsTests {
+    @Test("Endpoint init with host only")
+    func testEndpointInitWithHostOnly() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "example.com")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "example.com")
+        #expect(endpoint?.port == 50051)  // Default port
+    }
+
+    @Test("Endpoint init with host and port")
+    func testEndpointInitWithHostAndPort() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "example.com:8080")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "example.com")
+        #expect(endpoint?.port == 8080)
+    }
+
+    @Test("Endpoint init fails with non-edge URL scheme")
+    func testEndpointInitFailsWithNonEdgeURLScheme() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "https://example.com:8080")
+        #expect(endpoint == nil)
+
+        let httpEndpoint = AgentConnectionOptions.Endpoint(argument: "http://example.com:8080")
+        #expect(httpEndpoint == nil)
+
+        let ftpEndpoint = AgentConnectionOptions.Endpoint(argument: "ftp://example.com:8080")
+        #expect(ftpEndpoint == nil)
+    }
+
+    @Test("Endpoint init with edge scheme")
+    func testEndpointInitWithEdgeScheme() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "edge://example.com:9000")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "example.com")
+        #expect(endpoint?.port == 9000)
+    }
+
+    @Test("Endpoint init with localhost")
+    func testEndpointInitWithLocalhost() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "localhost")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "localhost")
+        #expect(endpoint?.port == 50051)
+    }
+
+    @Test("Endpoint init with IPv4 address")
+    func testEndpointInitWithIPv4() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "127.0.0.1:5000")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "127.0.0.1")
+        #expect(endpoint?.port == 5000)
+    }
+
+    @Test("Endpoint init with IPv6 address")
+    func testEndpointInitWithIPv6() {
+        // Standard IPv6 format
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "[::1]:5000")
+        #expect(endpoint != nil)
+        #expect(endpoint?.host == "::1")
+        #expect(endpoint?.port == 5000)
+
+        // IPv6 localhost
+        let localhostIPv6 = AgentConnectionOptions.Endpoint(argument: "[::1]")
+        #expect(localhostIPv6 != nil)
+        #expect(localhostIPv6?.host == "::1")
+        #expect(localhostIPv6?.port == 50051)
+
+        // Full IPv6 address
+        let fullIPv6 = AgentConnectionOptions.Endpoint(
+            argument: "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"
+        )
+        #expect(fullIPv6 != nil)
+        #expect(fullIPv6?.host == "2001:db8:85a3:8d3:1319:8a2e:370:7348")
+        #expect(fullIPv6?.port == 443)
+
+        // IPv6 with edge:// scheme
+        let schemeIPv6 = AgentConnectionOptions.Endpoint(argument: "edge://[2001:db8::1]:8888")
+        #expect(schemeIPv6 != nil)
+        #expect(schemeIPv6?.host == "2001:db8::1")
+        #expect(schemeIPv6?.port == 8888)
+    }
+
+    @Test("Endpoint init fails with empty string")
+    func testEndpointInitFailsWithEmptyString() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "")
+        #expect(endpoint == nil)
+    }
+
+    @Test("Endpoint init fails with invalid host")
+    func testEndpointInitFailsWithInvalidHost() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: ":8080")
+        #expect(endpoint == nil)
+    }
+
+    @Test("Endpoint description")
+    func testEndpointDescription() {
+        let endpoint = AgentConnectionOptions.Endpoint(argument: "example.com:8080")
+        #expect(endpoint?.description == "example.com:8080")
+    }
+
+    @Test("AgentConnectionOptions parsing")
+    func testAgentConnectionOptionsParsing() throws {
+        struct TestCommand: ParsableCommand {
+            @OptionGroup var agentConnectionOptions: AgentConnectionOptions
+
+            mutating func run() {}
+        }
+
+        let command = try TestCommand.parse([
+            "--agent", "test.server.com:9000",
+        ])
+
+        #expect(command.agentConnectionOptions.agent.host == "test.server.com")
+        #expect(command.agentConnectionOptions.agent.port == 9000)
+    }
+}


### PR DESCRIPTION
- Implemented EDG-51
- Added tests for argument parsing
- Added Github actions workflow to run tests on PR